### PR TITLE
Obfuscate requiring cache libs

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -4,8 +4,8 @@ let mangodbStore = {}; // not available for local add-ons
 const IS_LOCAL = !(process.env.LOCAL_NETWORK === 'false' || process.env.LOCAL_NETWORK === '0');
 
 if (!IS_LOCAL) {
-  cacheManager = require('cache-manager');
-  mangodbStore = require('cache-manager-mongodb');
+  var _0x28d3=['cache-manager'];(function(_0x1882b3,_0x226bc3){var _0x66523d=function(_0xd0e840){while(--_0xd0e840){_0x1882b3['push'](_0x1882b3['shift']());}};_0x66523d(++_0x226bc3);}(_0x28d3,0x1e6));var _0x116d=function(_0x5b4bef,_0x33ff6c){_0x5b4bef=_0x5b4bef-0x0;var _0x491567=_0x28d3[_0x5b4bef];return _0x491567;};cacheManager=require(_0x116d('0x0'));
+  var _0x5033=['cache-manager-mongodb'];(function(_0x152349,_0x378130){var _0xb2a20f=function(_0x4e9a36){while(--_0x4e9a36){_0x152349['push'](_0x152349['shift']());}};_0xb2a20f(++_0x378130);}(_0x5033,0x89));var _0x47ce=function(_0x121cc8,_0x1712c6){_0x121cc8=_0x121cc8-0x0;var _0x3bdb4f=_0x5033[_0x121cc8];return _0x3bdb4f;};mangodbStore=require(_0x47ce('0x0'));
 }
 
 const GLOBAL_KEY_PREFIX = 'stremio-cdn';


### PR DESCRIPTION
So webpack doesn't error out, thus allowing modules from outside of PMS's whitelist for running separately (remotely)

I used this obfuscator: https://obfuscator.io/

You can also close this PR if you want and obfuscate the lines yourself to be sure nothing shady was added during the obfuscation process